### PR TITLE
Support vertical alignment of comments

### DIFF
--- a/_ok.ps1
+++ b/_ok.ps1
@@ -18,8 +18,10 @@ function ok {
     cat $file | % {
       $line = $_.trim();
       if ($line -ne "" -and $line -ne $null) { 
-        $num = $num + 1;
-        $commands.Add(("" + $num), $line);
+        if ($line.indexOf('#') -gt 0) {
+          $num = $num + 1;
+          $commands.Add(("" + $num), $line);
+        }
       }
     }
     if ($number -ne $null -and $num -ge 1) {
@@ -39,16 +41,19 @@ function ok {
         ok_file $file
       }
     } else {
+      # Get length of longest command
+      $maxCommandLength = (($commands.Values | % { ($_ -split '#')[0] } | % { $_.Length }) | Measure-Object -Maximum ).Maximum
       # LIST the commands
-      $commands.GetEnumerator() | sort-object { [int]$_.Name }  | % {
-        write-host -NoNewline ($_.Name + ". ") -foregroundcolor "white"
-        $line = $_.Value
-        if ($line.indexOf('#') -ge 0) {
-          # write things before the # in one color and things after in green
-          write-host -NoNewline (($line -split '#')[0])
-          write-host $line.substring($line.indexOf('#')) -foregroundcolor "green"
+      $num = 0;
+      cat $file | % {
+        $command, $comment = $_.trim() -split '#'
+        if ($command) {
+          $num = $num + 1
+          Write-Host -NoNewLine "$num. " -foregroundcolor "white"
+          Write-Host -NoNewLine $command.PadRight($maxCommandLength, " ") -foregroundcolor "white"
+          Write-Host "#$comment" -foregroundcolor "green"
         } else {
-          write-host $_.Value
+          Write-Host "#$comment" -foregroundcolor "green"
         }
       }
     }

--- a/_ok.ps1
+++ b/_ok.ps1
@@ -15,10 +15,10 @@ function ok {
   function ok_file($file, $number, $arg) {
     $commands = @{};
     $num = 0;
-    cat $file | % {
+    type $file | % {
       $line = $_.trim();
       if ($line -ne "" -and $line -ne $null) { 
-        if ($line.indexOf('#') -gt 0) {
+        if ($line.indexOf('#') -ne 0) {
           $num = $num + 1;
           $commands.Add(("" + $num), $line);
         }
@@ -43,17 +43,20 @@ function ok {
     } else {
       # Get length of longest command
       $maxCommandLength = (($commands.Values | % { ($_ -split '#')[0] } | % { $_.Length }) | Measure-Object -Maximum ).Maximum
+      $maxCommentLength = (($commands.Values | % { ($_ -split '#')[1] } | % { $_.Length }) | Measure-Object -Maximum ).Maximum
       # LIST the commands
       $num = 0;
-      cat $file | % {
-        $command, $comment = $_.trim() -split '#'
+      type $file | % {
+        $command, $comment = $_.trim() -split '#' | % { $_.trim() }
         if ($command) {
           $num = $num + 1
           Write-Host -NoNewLine "$num. " -foregroundcolor "white"
-          Write-Host -NoNewLine $command.PadRight($maxCommandLength, " ") -foregroundcolor "white"
-          Write-Host "#$comment" -foregroundcolor "green"
+          Write-Host -NoNewLine $command.PadRight($maxCommandLength + 1, " ") -foregroundcolor "white"
+          if ($comment) { Write-Host "# $comment" -foregroundcolor "green" }
+          else { Write-Host "" }
         } else {
-          Write-Host "#$comment" -foregroundcolor "green"
+          if ($comment) { Write-Host "# $comment" -foregroundcolor "green" }
+          else { Write-Host "" }
         }
       }
     }


### PR DESCRIPTION
use `type` instead of `cat` because of `pwsh`
if a line begins with `#` then it's a heading
pads commands so that `#` are all aligned.